### PR TITLE
Add "Intent not Found"- Exception

### DIFF
--- a/Controller/RequestHandler.php
+++ b/Controller/RequestHandler.php
@@ -188,6 +188,8 @@ class RequestHandler
         if (class_exists($intentClass)) {
             $intent = new $intentClass($this->getRequestParser()->getRequest(), $this->getSystem());
             $intent->runIntent();
+        } else {
+         throw new \Exception($intentClass . ' not found');   
         }
     }
 


### PR DESCRIPTION
Neu: Fehlermeldung, wenn der RequestHandler den Intent nicht finden kann. Hilft ungemein beim debuggen, wenn man sich in den Namespaces verschtippt.